### PR TITLE
Add TUI stream listener and test channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Mount a volume to persist your recordings.
 
 | Key          | Action                                              |
 |--------------|-----------------------------------------------------|
+| `l`          | Listen to the selected live stream inside the TUI   |
+| `s`          | Stop TUI audio playback                             |
 | `q`          | Quit (graceful shutdown of all recordings)          |
 | `Ctrl+C`     | Quit (graceful shutdown of all recordings)          |
 | `SIGTERM`    | Graceful shutdown (e.g. `docker stop`)              |
@@ -185,6 +187,7 @@ The application works with sensible defaults — no configuration required.
 | `RECORDINGS_DIR`       | Directory to save recordings                 | `./recordings`      |
 | `TIMETABLE_PATH`       | Path to the timetable JSON                   | `dq-timetable.json` |
 | `TOOLS_DIR`            | Directory with bundled yt-dlp / ffmpeg       | exe directory       |
+| `TEST_MIXLR_CHANNEL`   | Optional extra Mixlr channel slug for testing | unset               |
 | `CHECK_INTERVAL_MS`    | Stream check interval (ms)                   | `60000`             |
 | `TUI_UPDATE_INTERVAL_MS` | UI refresh rate (ms)                        | `2000`              |
 

--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -71,5 +71,6 @@ func main() {
 	}
 
 	cancel()
+	ui.Close()
 	rec.StopAll(10 * time.Second)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/revunix/defqon1-recorder
 go 1.26
 
 require (
+	github.com/ebitengine/oto/v3 v3.4.0
 	github.com/gdamore/tcell/v2 v2.13.10
 	github.com/rivo/tview v0.42.0
 )
 
 require (
+	github.com/ebitengine/purego v0.9.0 // indirect
 	github.com/gdamore/encoding v1.0.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/ebitengine/oto/v3 v3.4.0 h1:br0PgASsEWaoWn38b2Goe7m1GKFYfNgnsjSd5Gg+/bQ=
+github.com/ebitengine/oto/v3 v3.4.0/go.mod h1:IOleLVD0m+CMak3mRVwsYY8vTctQgOM0iiL6S7Ar7eI=
+github.com/ebitengine/purego v0.9.0 h1:mh0zpKBIXDceC63hpvPuGLiJ8ZAa3DfrFTudmfi8A4k=
+github.com/ebitengine/purego v0.9.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
 github.com/gdamore/tcell/v2 v2.13.10 h1:Afs3JKt83HnhuUKdZ3MnxUgOqQRWftj5JyDqv1LLynA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -20,24 +21,27 @@ type Config struct {
 }
 
 func Default() Config {
+	channels := []string{
+		"defqon-1-magenta", // DQ.1 Magenta
+		"defqon1purple",    // DQ.1 Purple
+		"defqon1white",     // DQ.1 White
+		"defqon-1-brown",   // DQ.1 Brown
+		"defqon1pink",      // DQ.1 Pink
+		"defqon1blue",      // DQ.1 Blue
+		"defqon1indigo",    // DQ.1 Indigo
+		"defqon1yellow",    // DQ.1 Yellow
+		"defqon1orange",    // DQ.1 Orange
+		"defqon1silver",    // DQ.1 Silver
+		"defqon1green",     // DQ.1 Green
+		"defqon1gold",      // DQ.1 Gold
+		"defqon1black",     // DQ.1 Black
+		"defqon1uv",        // DQ.1 UV
+	}
+	channels = appendEnvChannels(channels, "TEST_MIXLR_CHANNEL")
+
 	return Config{
-		APIBaseURL: "https://apicdn.mixlr.com/v3/channel_view/",
-		Channels: []string{
-			"defqon-1-magenta", // DQ.1 Magenta
-			"defqon1purple",    // DQ.1 Purple
-			"defqon1white",     // DQ.1 White
-			"defqon-1-brown",   // DQ.1 Brown
-			"defqon1pink",      // DQ.1 Pink
-			"defqon1blue",      // DQ.1 Blue
-			"defqon1indigo",    // DQ.1 Indigo
-			"defqon1yellow",    // DQ.1 Yellow
-			"defqon1orange",    // DQ.1 Orange
-			"defqon1silver",    // DQ.1 Silver
-			"defqon1green",     // DQ.1 Green
-			"defqon1gold",      // DQ.1 Gold
-			"defqon1black",     // DQ.1 Black
-			"defqon1uv",        // DQ.1 UV
-		},
+		APIBaseURL:           "https://apicdn.mixlr.com/v3/channel_view/",
+		Channels:             channels,
 		RecordingsDir:        envOr("RECORDINGS_DIR", "recordings"),
 		TimetablePath:        envOr("TIMETABLE_PATH", "dq-timetable.json"),
 		ToolsDir:             envOr("TOOLS_DIR", exeDir()),
@@ -46,6 +50,26 @@ func Default() Config {
 		StalledTimeout:       60 * time.Second,
 		TUIUpdateInterval:    envDurationMSOr("TUI_UPDATE_INTERVAL_MS", 2_000*time.Millisecond),
 	}
+}
+
+func appendEnvChannels(channels []string, key string) []string {
+	for _, raw := range strings.Split(os.Getenv(key), ",") {
+		channel := strings.TrimSpace(raw)
+		if channel == "" || contains(channels, channel) {
+			continue
+		}
+		channels = append(channels, channel)
+	}
+	return channels
+}
+
+func contains(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
 }
 
 func envOr(key, def string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,23 @@
+package config
+
+import "testing"
+
+func TestDefaultAppendsTestMixlrChannel(t *testing.T) {
+	t.Setenv("TEST_MIXLR_CHANNEL", "orocash-music, defqon1blue")
+
+	cfg := Default()
+
+	if cfg.Channels[len(cfg.Channels)-1] != "orocash-music" {
+		t.Fatalf("expected test channel appended last, got %q", cfg.Channels[len(cfg.Channels)-1])
+	}
+
+	count := 0
+	for _, ch := range cfg.Channels {
+		if ch == "defqon1blue" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected duplicate default channel skipped, got %d copies", count)
+	}
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/revunix/defqon1-recorder/internal/logging"
@@ -44,33 +45,44 @@ func (c *Controller) CheckOnce(ctx context.Context) {
 	c.log.Info(fmt.Sprintf("--- Checking channels at %s ---",
 		time.Now().In(util.Berlin()).Format("15:04:05")))
 
+	var wg sync.WaitGroup
 	for _, channel := range c.channels {
-		ch, err := c.client.Fetch(ctx, channel)
-		if err != nil {
-			c.log.Error(fmt.Sprintf("[%s] Fetch Error: %s", channel, err))
-			// Keep the last known status on transient errors.
-			continue
-		}
+		channel := channel
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.checkChannel(ctx, channel)
+		}()
+	}
+	wg.Wait()
+}
 
-		stage := ch.Username
-		if stage == "" {
-			stage = channel
-		}
-		c.status.Set(channel, stage, ch.Live, ch.ListenerCount)
+func (c *Controller) checkChannel(ctx context.Context, channel string) {
+	ch, err := c.client.Fetch(ctx, channel)
+	if err != nil {
+		c.log.Error(fmt.Sprintf("[%s] Fetch Error: %s", channel, err))
+		// Keep the last known status on transient errors.
+		return
+	}
 
-		if ch.Live && ch.StreamURL != "" {
-			if c.recorder.IsRecording(stage) {
-				c.recorder.UpdateListeners(stage, ch.ListenerCount)
-			} else {
-				c.recorder.Start(stage, ch.StreamURL, ch.ListenerCount)
-			}
-			continue
-		}
+	stage := ch.Username
+	if stage == "" {
+		stage = channel
+	}
+	c.status.Set(channel, stage, ch.Live, ch.ListenerCount, ch.StreamURL)
 
+	if ch.Live && ch.StreamURL != "" {
 		if c.recorder.IsRecording(stage) {
-			c.log.Info(fmt.Sprintf("[%s] Offline. Stopping recording.", stage))
-			c.recorder.Stop(stage)
+			c.recorder.UpdateListeners(stage, ch.ListenerCount)
+		} else {
+			c.recorder.Start(stage, ch.StreamURL, ch.ListenerCount)
 		}
+		return
+	}
+
+	if c.recorder.IsRecording(stage) {
+		c.log.Info(fmt.Sprintf("[%s] Offline. Stopping recording.", stage))
+		c.recorder.Stop(stage)
 	}
 }
 

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -1,0 +1,222 @@
+package listener
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ebitengine/oto/v3"
+
+	"github.com/revunix/defqon1-recorder/internal/tools"
+)
+
+const (
+	sampleRate   = 48000
+	channelCount = 2
+)
+
+type State string
+
+const (
+	StateStopped  State = "Stopped"
+	StateStarting State = "Starting"
+	StatePlaying  State = "Playing"
+)
+
+type Snapshot struct {
+	State State
+	Stage string
+}
+
+type Player struct {
+	ffmpeg string
+
+	mu      sync.Mutex
+	ctx     *oto.Context
+	current *session
+}
+
+type session struct {
+	stage  string
+	cmd    *exec.Cmd
+	player *oto.Player
+	done   chan struct{}
+	state  State
+}
+
+func New(toolsDir string) *Player {
+	return &Player{ffmpeg: tools.Resolve(toolsDir).FFmpeg}
+}
+
+func (p *Player) Play(stage, streamURL string) error {
+	if err := validateURL(streamURL); err != nil {
+		return err
+	}
+
+	p.Stop()
+
+	ctx, err := p.context()
+	if err != nil {
+		return err
+	}
+
+	args := []string{
+		"-hide_banner", "-nostdin", "-loglevel", "error",
+		"-i", streamURL,
+		"-vn",
+		"-f", "s16le",
+		"-acodec", "pcm_s16le",
+		"-ac", fmt.Sprint(channelCount),
+		"-ar", fmt.Sprint(sampleRate),
+		"pipe:1",
+	}
+	cmd := exec.Command(p.ffmpeg, args...)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("ffmpeg stdout: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("ffmpeg stderr: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start ffmpeg: %w", err)
+	}
+
+	otoPlayer := ctx.NewPlayer(stdout)
+	otoPlayer.SetBufferSize(sampleRate * channelCount * 2)
+
+	s := &session{
+		stage:  stage,
+		cmd:    cmd,
+		player: otoPlayer,
+		done:   make(chan struct{}),
+		state:  StateStarting,
+	}
+
+	p.mu.Lock()
+	p.current = s
+	p.mu.Unlock()
+
+	go drain(stderr)
+	otoPlayer.Play()
+	p.setState(s, StatePlaying)
+
+	go p.wait(s)
+	return nil
+}
+
+func (p *Player) Stop() {
+	p.mu.Lock()
+	s := p.current
+	if s == nil {
+		p.mu.Unlock()
+		return
+	}
+	p.current = nil
+	p.mu.Unlock()
+
+	s.stop()
+}
+
+func (p *Player) Snapshot() Snapshot {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.current == nil {
+		return Snapshot{State: StateStopped}
+	}
+	return Snapshot{State: p.current.state, Stage: p.current.stage}
+}
+
+func (p *Player) context() (*oto.Context, error) {
+	p.mu.Lock()
+	if p.ctx != nil {
+		ctx := p.ctx
+		p.mu.Unlock()
+		return ctx, nil
+	}
+
+	ctx, ready, err := oto.NewContext(&oto.NewContextOptions{
+		SampleRate:   sampleRate,
+		ChannelCount: channelCount,
+		Format:       oto.FormatSignedInt16LE,
+		BufferSize:   500 * time.Millisecond,
+	})
+	if err != nil {
+		p.mu.Unlock()
+		return nil, fmt.Errorf("audio device: %w", err)
+	}
+
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		p.mu.Unlock()
+		return nil, errors.New("audio device did not become ready")
+	}
+
+	p.ctx = ctx
+	p.mu.Unlock()
+
+	return ctx, nil
+}
+
+func (p *Player) setState(s *session, state State) {
+	p.mu.Lock()
+	if p.current == s {
+		s.state = state
+	}
+	p.mu.Unlock()
+}
+
+func (p *Player) wait(s *session) {
+	_ = s.cmd.Wait()
+	_ = s.player.Close()
+	close(s.done)
+
+	p.mu.Lock()
+	if p.current == s {
+		p.current = nil
+	}
+	p.mu.Unlock()
+}
+
+func (s *session) stop() {
+	if s.player != nil {
+		_ = s.player.Close()
+	}
+	if s.cmd != nil && s.cmd.Process != nil {
+		_ = s.cmd.Process.Kill()
+	}
+	select {
+	case <-s.done:
+	case <-time.After(2 * time.Second):
+	}
+}
+
+func validateURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("unsupported URL scheme %q", parsed.Scheme)
+	}
+	return nil
+}
+
+func drain(r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) == "" {
+			continue
+		}
+	}
+}

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -286,6 +287,13 @@ func (m *Manager) forceKill(stage string) {
 // interrupt asks both processes to shut down gracefully so ffmpeg can finalize
 // a valid MP3 (it flushes and writes the trailer on SIGINT).
 func (r *recording) interrupt() {
+	if runtime.GOOS == "windows" {
+		// os.Interrupt is not delivered to child processes on Windows. Kill both
+		// tools immediately so quitting the TUI cannot leave a hidden recorder
+		// waiting for the force-kill timeout.
+		r.kill()
+		return
+	}
 	if r.ytdlp.Process != nil {
 		_ = r.ytdlp.Process.Signal(os.Interrupt)
 	}

--- a/internal/status/registry.go
+++ b/internal/status/registry.go
@@ -9,6 +9,7 @@ type Stream struct {
 	Channel       string
 	Stage         string
 	Online        bool
+	StreamURL     string
 	ListenerCount int
 	UpdatedAt     time.Time
 }
@@ -33,7 +34,7 @@ func New(channels []string) *Registry {
 	return r
 }
 
-func (r *Registry) Set(channel, stage string, online bool, listeners int) {
+func (r *Registry) Set(channel, stage string, online bool, listeners int, streamURL string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -47,6 +48,11 @@ func (r *Registry) Set(channel, stage string, online bool, listeners int) {
 		s.Stage = stage
 	}
 	s.Online = online
+	if online {
+		s.StreamURL = streamURL
+	} else {
+		s.StreamURL = ""
+	}
 	s.ListenerCount = listeners
 	s.UpdatedAt = time.Now()
 }

--- a/internal/status/registry_test.go
+++ b/internal/status/registry_test.go
@@ -13,8 +13,8 @@ func TestRegistryOrderAndSet(t *testing.T) {
 		t.Fatal("entries should start offline")
 	}
 
-	r.Set("b", "BLUE", true, 42)
-	r.Set("unknown", "X", true, 1)
+	r.Set("b", "BLUE", true, 42, "https://listen.mixlr.com/live")
+	r.Set("unknown", "X", true, 1, "https://listen.mixlr.com/unknown")
 
 	all = r.All()
 	// original order preserved, unknown appended last
@@ -34,7 +34,15 @@ func TestRegistryOrderAndSet(t *testing.T) {
 			blue = &all[i]
 		}
 	}
-	if blue == nil || !blue.Online || blue.ListenerCount != 42 || blue.Stage != "BLUE" {
+	if blue == nil || !blue.Online || blue.ListenerCount != 42 || blue.Stage != "BLUE" || blue.StreamURL == "" {
 		t.Fatalf("blue stream not updated correctly: %+v", blue)
+	}
+
+	r.Set("b", "BLUE", false, 0, "https://listen.mixlr.com/live")
+	all = r.All()
+	for i := range all {
+		if all[i].Channel == "b" && all[i].StreamURL != "" {
+			t.Fatalf("offline stream should not keep listen URL: %+v", all[i])
+		}
 	}
 }

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rivo/tview"
 
 	"github.com/revunix/defqon1-recorder/internal/config"
+	"github.com/revunix/defqon1-recorder/internal/listener"
 	"github.com/revunix/defqon1-recorder/internal/logging"
 	"github.com/revunix/defqon1-recorder/internal/recorder"
 	"github.com/revunix/defqon1-recorder/internal/status"
@@ -59,6 +60,7 @@ type UI struct {
 	logView   *tview.TextView
 	statusBar *tview.TextView
 	recorder  *recorder.Manager
+	listener  *listener.Player
 	timetable *timetable.Timetable
 	streams   *status.Registry
 	cfg       config.Config
@@ -76,6 +78,7 @@ func New(
 		app:       tview.NewApplication(),
 		cfg:       cfg,
 		recorder:  rec,
+		listener:  listener.New(cfg.ToolsDir),
 		timetable: tt,
 		streams:   streams,
 		logCh:     logCh,
@@ -85,8 +88,8 @@ func New(
 }
 
 func (u *UI) build() {
-	u.streamTbl = newTable(" Streams ")
-	u.ttTable = newTable(" Timetable ")
+	u.streamTbl = newTable(" Streams ", true)
+	u.ttTable = newTable(" Timetable ", false)
 
 	u.logView = tview.NewTextView().
 		SetDynamicColors(true).
@@ -114,14 +117,26 @@ func (u *UI) build() {
 			u.app.Stop()
 			return nil
 		}
+		if event.Rune() == 'l' || event.Rune() == 'L' {
+			u.listenSelected()
+			return nil
+		}
+		if event.Rune() == 's' || event.Rune() == 'S' {
+			u.stopListening()
+			return nil
+		}
 		return event
 	})
+	u.app.SetFocus(u.streamTbl)
 }
 
-func newTable(title string) *tview.Table {
+func newTable(title string, selectable bool) *tview.Table {
 	t := tview.NewTable().
 		SetBorders(false).
-		SetSelectable(false, false)
+		SetSelectable(selectable, false)
+	if selectable {
+		t.SetFixed(1, 0)
+	}
 	t.SetTitle(title).SetBorder(true)
 	return t
 }
@@ -134,6 +149,10 @@ func (u *UI) Run() error {
 // Stop ends the event loop; safe to call from any goroutine (e.g. signal handler).
 func (u *UI) Stop() {
 	u.app.Stop()
+}
+
+func (u *UI) Close() {
+	u.listener.Stop()
 }
 
 func (u *UI) RunRefresh(ctx context.Context) {
@@ -159,10 +178,12 @@ func (u *UI) refresh() {
 		renderCells(u.streamTbl,
 			[]string{"Stage", "Status", "Artist", "Listeners", "Size", "Ends in"},
 			streamRows,
+			true,
 		)
 		renderCells(u.ttTable,
 			[]string{"Stage", "Time", "Artist", "Starts In"},
 			ttRows,
+			false,
 		)
 		u.statusBar.SetText(status)
 	})
@@ -247,22 +268,87 @@ func (u *UI) buildTimetableRows() [][]cell {
 }
 
 func (u *UI) buildStatusBar() string {
+	audio := u.listener.Snapshot()
+	audioText := string(audio.State)
+	if audio.Stage != "" {
+		audioText = fmt.Sprintf("%s: %s", audio.State, audio.Stage)
+	}
 	return util.Sanitize(fmt.Sprintf(
-		"DEFQON.1 Recorder by revunix | Active: %d/%d | Total Listeners: %s",
+		"DEFQON.1 Recorder by revunix | Active: %d/%d | Total Listeners: %s | Audio: %s",
 		u.recorder.Count(),
 		len(u.cfg.Channels),
 		util.FormatThousands(u.recorder.TotalListeners()),
+		audioText,
 	))
+}
+
+func (u *UI) listenSelected() {
+	stream, ok := u.selectedStream()
+	if !ok {
+		u.appendLog(LogMessage{Level: logging.LevelWarn, Text: "No stream selected."})
+		return
+	}
+	if !stream.Online || stream.StreamURL == "" {
+		u.appendLog(LogMessage{Level: logging.LevelWarn, Text: fmt.Sprintf("[%s] No live stream URL available.", stream.Stage)})
+		return
+	}
+
+	stage := stream.Stage
+	streamURL := stream.StreamURL
+	u.appendLog(LogMessage{Level: logging.LevelInfo, Text: fmt.Sprintf("[%s] Starting TUI audio...", stage)})
+	go func() {
+		if err := u.listener.Play(stage, streamURL); err != nil {
+			u.queueLog(LogMessage{Level: logging.LevelError, Text: fmt.Sprintf("[%s] Audio failed: %s", stage, err)})
+			return
+		}
+		u.queueLog(LogMessage{Level: logging.LevelInfo, Text: fmt.Sprintf("[%s] TUI audio playing.", stage)})
+	}()
+}
+
+func (u *UI) stopListening() {
+	audio := u.listener.Snapshot()
+	if audio.State == listener.StateStopped {
+		u.appendLog(LogMessage{Level: logging.LevelWarn, Text: "Audio is already stopped."})
+		return
+	}
+	u.listener.Stop()
+	u.appendLog(LogMessage{Level: logging.LevelInfo, Text: "TUI audio stopped."})
+}
+
+func (u *UI) selectedStream() (status.Stream, bool) {
+	row, _ := u.streamTbl.GetSelection()
+	streams := u.streams.All()
+	if len(streams) == 0 {
+		return status.Stream{}, false
+	}
+	if row < 1 {
+		row = 1
+	}
+	idx := row - 1
+	if idx >= len(streams) {
+		idx = len(streams) - 1
+	}
+	u.streamTbl.Select(idx+1, 0)
+	return streams[idx], true
 }
 
 func (u *UI) drainLogs() {
 	for msg := range u.logCh {
-		line := formatLog(msg)
 		u.app.QueueUpdateDraw(func() {
-			fmt.Fprintln(u.logView, line)
-			u.logView.ScrollToEnd()
+			u.appendLog(msg)
 		})
 	}
+}
+
+func (u *UI) appendLog(msg LogMessage) {
+	fmt.Fprintln(u.logView, formatLog(msg))
+	u.logView.ScrollToEnd()
+}
+
+func (u *UI) queueLog(msg LogMessage) {
+	u.app.QueueUpdateDraw(func() {
+		u.appendLog(msg)
+	})
 }
 
 func formatLog(msg LogMessage) string {
@@ -282,7 +368,8 @@ type cell struct {
 	color tcell.Color
 }
 
-func renderCells(t *tview.Table, headers []string, rows [][]cell) {
+func renderCells(t *tview.Table, headers []string, rows [][]cell, preserveSelection bool) {
+	selectedRow, selectedCol := t.GetSelection()
 	t.Clear()
 	for c, h := range headers {
 		t.SetCell(0, c, tview.NewTableCell(h).
@@ -293,12 +380,20 @@ func renderCells(t *tview.Table, headers []string, rows [][]cell) {
 	for r, row := range rows {
 		for c, cl := range row {
 			tc := tview.NewTableCell(cl.text).
-				SetMaxWidth(50).
-				SetSelectable(false)
+				SetMaxWidth(50)
 			if cl.color != tcell.ColorDefault {
 				tc.SetTextColor(cl.color)
 			}
 			t.SetCell(r+1, c, tc)
 		}
+	}
+	if preserveSelection && len(rows) > 0 {
+		if selectedRow < 1 {
+			selectedRow = 1
+		}
+		if selectedRow > len(rows) {
+			selectedRow = len(rows)
+		}
+		t.Select(selectedRow, selectedCol)
 	}
 }


### PR DESCRIPTION
## Summary
- add optional TEST_MIXLR_CHANNEL support for ad-hoc live stream testing
- add selectable stream rows plus l/s controls for in-TUI audio playback
- add an internal ffmpeg -> Oto audio listener so streams play without opening a browser
- parallelize channel checks and improve Windows child-process shutdown

## Testing
- go test ./...
- smoke-tested with TEST_MIXLR_CHANNEL=orocash-music: selected Orocash, started TUI audio, stopped TUI audio, and verified no leftover ffmpeg/yt-dlp/recorder processes