### PR TITLE
Fix Docker build for TUI audio support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,13 @@
 # Build artifacts & toolchain output
 /dist/
 /bin/
+/build/
 /defqon-recorder
+/external tools/
 
 # Runtime data
 /recordings/
+/docker-recordings/
 *.mp3
 *.log
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM golang:1.26-alpine AS builder
 
 WORKDIR /src
 
+# Oto uses ALSA through cgo on Linux.
+RUN apk add --no-cache build-base pkgconf alsa-lib-dev
+
 # Cache dependencies first.
 COPY go.mod go.sum ./
 RUN go mod download
@@ -12,7 +15,7 @@ RUN go mod download
 COPY . .
 
 ARG VERSION=dev
-RUN CGO_ENABLED=0 go build \
+RUN CGO_ENABLED=1 go build \
     -ldflags "-s -w -X main.version=${VERSION}" \
     -o /out/defqon-recorder ./cmd/recorder
 
@@ -20,7 +23,7 @@ RUN CGO_ENABLED=0 go build \
 FROM alpine:3.20
 
 # yt-dlp and FFmpeg are required at runtime to download/convert streams.
-RUN apk add --no-cache ca-certificates ffmpeg yt-dlp \
+RUN apk add --no-cache ca-certificates ffmpeg yt-dlp alsa-lib \
     && addgroup -S app && adduser -S -G app app
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ docker run --rm -it -v "$PWD/recordings:/app/recordings" defqon-recorder
 
 The image bundles yt-dlp and FFmpeg, so only Docker is required to run it.
 Mount a volume to persist your recordings.
+To use TUI audio playback from inside Docker on Linux, pass through the host
+sound device as well, for example `--device /dev/snd`.
 
 ## 🎛️ Controls
 


### PR DESCRIPTION
## Summary
- build the Docker image with cgo enabled so the Linux TUI audio backend is included
- install ALSA development packages in the build stage and ALSA runtime libraries in the final image
- document that Docker audio playback needs host sound device passthrough, for example `--device /dev/snd`

## Testing
- go test ./...

Docker build was not run locally because the Docker Desktop Linux engine is not available in this environment.