### PR TITLE
Fix timetable timezone data in minimal builds

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	// Embed IANA tzdata for Windows and minimal container builds, which may not
+	// have a system zoneinfo database to satisfy time.LoadLocation.
+	_ "time/tzdata"
 )
 
 var (

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,6 +1,9 @@
 package util
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestFormatBytes(t *testing.T) {
 	cases := map[int64]string{
@@ -45,6 +48,18 @@ func TestFormatThousands(t *testing.T) {
 		if got := FormatThousands(in); got != want {
 			t.Errorf("FormatThousands(%d) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestBerlinUsesSummerTimeInJune(t *testing.T) {
+	loc := Berlin()
+	start := time.Date(2026, time.June, 25, 20, 0, 0, 0, loc)
+	_, offset := start.Zone()
+	if offset != 2*60*60 {
+		t.Fatalf("2026-06-25 20:00 zone offset = %d seconds, want %d", offset, 2*60*60)
+	}
+	if got := start.UTC().Format("15:04"); got != "18:00" {
+		t.Fatalf("2026-06-25 20:00 event time resolves to UTC %s, want 18:00", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- embed Go's IANA timezone database so Europe/Berlin loads correctly in Windows and minimal container builds
- add a regression test that verifies DEFQON June timetable times use CEST/UTC+2 instead of fixed CET/UTC+1

## Testing
- docker run --rm -v ${PWD}:/src -w /src golang:1.26 go test ./...